### PR TITLE
SEENG 1.2.3 Update

### DIFF
--- a/Plugins/SEENG_ES.xml
+++ b/Plugins/SEENG_ES.xml
@@ -15,7 +15,7 @@
   
   Allows to make your own sound packs</Description>
 
-  <Commit>5b7f8e3992fd1ee01fd3f3b08e6d98db791eae59</Commit>
+  <Commit>adabecbe41d36a31c802b939ccdf6df48ddf4cc0</Commit>
 
   <ImplicitUsings>true</ImplicitUsings> 
 </PluginData>


### PR DESCRIPTION
- Changed Max Audio distance from **650m** to **World.Sync.Distance** (scan to 6500m)
- Fixed Engine50 handler using static parameters
- Fixed Engine config working locally
- Fixed Ships engine being loud on idle
- Fixed Ships not switching to idle sound
- Fixed RefitEngine sometimes break sound update