### PR TITLE
SEENG Hotfix

### DIFF
--- a/Plugins/SEENG_ES.xml
+++ b/Plugins/SEENG_ES.xml
@@ -15,7 +15,7 @@
   
   Allows to make your own sound packs</Description>
 
-  <Commit>edde3d9d9eba09728ff6bdf3ba44e965911ac8e3</Commit>
+  <Commit>3bac706af67a7cd7afa5cd16264764e90a2d697c</Commit>
 
   <ImplicitUsings>true</ImplicitUsings> 
 </PluginData>


### PR DESCRIPTION
- Fixed news module initiates before modmanager, causing image search to fail