### PR TITLE
SEENG 1.3.7 Update

### DIFF
--- a/Plugins/SEENG_ES.xml
+++ b/Plugins/SEENG_ES.xml
@@ -15,7 +15,7 @@
   
   Allows to make your own sound packs</Description>
 
-  <Commit>b2f52161dce243aab2de13bbe960fb12f939424b</Commit>
+  <Commit>7cbca682c6d006fe1e4dc7f8f66ae297f7249f3c</Commit>
 
   <ImplicitUsings>true</ImplicitUsings> 
 </PluginData>

--- a/Plugins/SEENG_ES.xml
+++ b/Plugins/SEENG_ES.xml
@@ -15,7 +15,7 @@
   
   Allows to make your own sound packs</Description>
 
-  <Commit>0ae72bb4a7e5ab15d3acef57a400254f9acd6a3d</Commit>
+  <Commit>b2f52161dce243aab2de13bbe960fb12f939424b</Commit>
 
   <ImplicitUsings>true</ImplicitUsings> 
 </PluginData>

--- a/Plugins/SEENG_ES.xml
+++ b/Plugins/SEENG_ES.xml
@@ -2,7 +2,7 @@
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
   <Id>StrongBroArina2/SEENG_ES</Id>
   
-  <FriendlyName>SEENG: Engine Sounds! 1.3.4</FriendlyName>
+  <FriendlyName>SEENG: Engine Sounds! 1.3.7</FriendlyName>
   
   <Author>dogboy</Author>
   
@@ -15,7 +15,7 @@
   
   Allows to make your own sound packs</Description>
 
-  <Commit>3bac706af67a7cd7afa5cd16264764e90a2d697c</Commit>
+  <Commit>0ae72bb4a7e5ab15d3acef57a400254f9acd6a3d</Commit>
 
   <ImplicitUsings>true</ImplicitUsings> 
 </PluginData>


### PR DESCRIPTION
- Added Volume mixer
- Updated Volume Menu UI

- Fixed ACDCadv sound cut to early
[now slowly fades away]
- Fixed Maneuver thrusters positional sounds play from camera perspective
rather than from cockpit

- Added Power depended Engine sound
[sound pitch react to grids power consumption level in%]

- Fixed MoveAmbience sound causing crashes

- Added shortcut for debug command - /seeng d
[yes sir]

- Fixed spaghetti code in - SoundHandler
- Added new spaghetti code to SoundHandler

- Changed scan speed [performance]
from 60 ticks to 160